### PR TITLE
Let Play write it's superfluous RUNNING_PID file somewhere harmless

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -35,6 +35,16 @@ serverLoading in Debian := Systemd
 
 debianPackageDependencies := Seq("openjdk-8-jre-headless")
 
+javaOptions in Universal ++= Seq(
+  "-Dpidfile.path=/dev/null",
+  "-J-XX:MaxRAMFraction=2",
+  "-J-XX:InitialRAMFraction=2",
+  "-J-XX:MaxMetaspaceSize=500m",
+  "-J-XX:+PrintGCDetails",
+  "-J-XX:+PrintGCDateStamps",
+  s"-J-Xloggc:/var/log/${name.value}/gc.log"
+)
+
 maintainer := "The Maintainer <the.maintainer@company.com>"
 
 packageSummary := "Brief description"

--- a/build.sbt
+++ b/build.sbt
@@ -45,12 +45,11 @@ javaOptions in Universal ++= Seq(
   s"-J-Xloggc:/var/log/${name.value}/gc.log"
 )
 
-maintainer := "The Maintainer <the.maintainer@company.com>"
+maintainer := "Membership Discovery <membership.dev@theguardian.com>"
 
-packageSummary := "Brief description"
+packageSummary := "Friendly Tailor service"
 
-packageDescription := """Slightly longer description"""
-
+packageDescription := """Friendly Tailor reads and stores Ophan events to measure reader background knowledge"""
 
 riffRaffPackageType := (packageBin in Debian).value
 


### PR DESCRIPTION
We were deploying to Prod, but logs showed that Play was trying to write the PID file where it didn't have permission:

```
FileNotFoundException: /usr/share/friendly-tailor/RUNNING_PID (Permission denied)
```

See also https://github.com/guardian/status-app/commit/0bb17def


```
$ journalctl -u friendly-tailor
May 03 17:10:47 ip-10-248-132-14 systemd[1]: Started Brief description.
May 03 17:10:47 ip-10-248-132-14 friendly-tailor[2278]: Oops, cannot start the server.
May 03 17:10:47 ip-10-248-132-14 friendly-tailor[2278]: java.io.FileNotFoundException: /usr/share/friendly-tailor/RUNNING_PID (Permission denied)
May 03 17:10:47 ip-10-248-132-14 friendly-tailor[2278]: at java.io.FileOutputStream.open0(Native Method)
May 03 17:10:47 ip-10-248-132-14 friendly-tailor[2278]: at java.io.FileOutputStream.open(FileOutputStream.java:270)
May 03 17:10:47 ip-10-248-132-14 friendly-tailor[2278]: at java.io.FileOutputStream.<init>(FileOutputStream.java:213)
May 03 17:10:47 ip-10-248-132-14 friendly-tailor[2278]: at java.io.FileOutputStream.<init>(FileOutputStream.java:162)
May 03 17:10:47 ip-10-248-132-14 friendly-tailor[2278]: at play.core.server.ProdServerStart$.createPidFile(ProdServerStart.scala:131)
May 03 17:10:47 ip-10-248-132-14 friendly-tailor[2278]: at play.core.server.ProdServerStart$.start(ProdServerStart.scala:45)
May 03 17:10:47 ip-10-248-132-14 friendly-tailor[2278]: at play.core.server.ProdServerStart$.main(ProdServerStart.scala:27)
May 03 17:10:47 ip-10-248-132-14 friendly-tailor[2278]: at play.core.server.ProdServerStart.main(ProdServerStart.scala)
May 03 17:10:47 ip-10-248-132-14 systemd[1]: friendly-tailor.service: Main process exited, code=exited, status=255/n/a
May 03 17:10:47 ip-10-248-132-14 systemd[1]: friendly-tailor.service: Unit entered failed state.
May 03 17:10:47 ip-10-248-132-14 systemd[1]: friendly-tailor.service: Failed with result 'exit-code'.
May 03 17:11:47 ip-10-248-132-14 systemd[1]: friendly-tailor.service: Service hold-off time over, scheduling restart.
May 03 17:11:47 ip-10-248-132-14 systemd[1]: Stopped Brief description.
```

cc @annebyrne @philwills 