### PR TITLE
Adding sbt-buildinfo using a workaround for Scrooge-clash

### DIFF
--- a/app/controllers/Management.scala
+++ b/app/controllers/Management.scala
@@ -7,8 +7,7 @@ import play.api.mvc._
 object Management extends Controller with LazyLogging {
 
   def healthcheck = Action {
-
-    Ok(s"OK ${EventsConsumer.worker}")
+    Ok(s"OK\n${app.BuildInfo.gitVersionId}\n${EventsConsumer.worker}")
   }
 
 }

--- a/build.sbt
+++ b/build.sbt
@@ -3,6 +3,7 @@ name := "friendly-tailor"
 version := "1.0-SNAPSHOT"
 
 lazy val root = (project in file(".")).enablePlugins(
+  BuildInfoPlugin,
   PlayScala,
   RiffRaffArtifact,
   JDebPackaging
@@ -25,6 +26,11 @@ libraryDependencies ++= Seq(
 sources in (Compile,doc) := Seq.empty
 
 publishArtifact in (Compile, packageDoc) := false
+
+
+scroogeThriftOutputFolder in Compile := sourceManaged.value / "thrift"
+
+managedSourceDirectories in Compile += (scroogeThriftOutputFolder in Compile).value
 
 testOptions in Test ++= Seq(
     Tests.Argument("-oD") // display full stack errors and execution times in Scalatest output
@@ -64,3 +70,17 @@ riffRaffManifestBranch := env("BRANCH_NAME").getOrElse("unknown_branch")
 riffRaffBuildIdentifier := env("BUILD_NUMBER").getOrElse("DEV")
 
 riffRaffManifestVcsUrl  := "git@github.com:guardian/friendly-tailor.git"
+
+
+buildInfoKeys := Seq[BuildInfoKey](
+  name,
+  BuildInfoKey.constant("gitCommitId", env("BUILD_VCS_NUMBER") getOrElse (try {
+    "git rev-parse HEAD".!!.trim
+  } catch {
+    case e: Exception => "unknown"
+  })),
+  BuildInfoKey.constant("buildNumber", env("BUILD_NUMBER") getOrElse "DEV"),
+  BuildInfoKey.constant("buildTime", System.currentTimeMillis)
+)
+
+buildInfoPackage := "app"


### PR DESCRIPTION
sbt-buildinfo lets us write build-related information into our Scala code,
so we can more easily see what exact version of code is running, and use
deployment monitoring tools like Prout.

sbt-buildinfo clashed with Scrooge, but this workaround was suggested with:

https://github.com/sbt/sbt-buildinfo/issues/88#issuecomment-216541181

cc @annebyrne 