### PR TITLE
Add Prout, to track pull request deployment

### DIFF
--- a/.prout.json
+++ b/.prout.json
@@ -1,0 +1,8 @@
+{
+    "checkpoints": {
+        "PROD": {
+            "url": "http://friendly-elasticl-9snnlm6xn0d5-1747586787.eu-west-1.elb.amazonaws.com/healthcheck",
+            "overdue": "10M"
+        }
+    }
+}


### PR DESCRIPTION
https://www.theguardian.com/info/developer-blog/2015/feb/03/prout-is-your-pull-request-out

cc @annebyrne 