### PR TITLE
fix content-tag data to be automatically refreshed

### DIFF
--- a/app/com/gu/friendly/tailor/EventsConsumer.scala
+++ b/app/com/gu/friendly/tailor/EventsConsumer.scala
@@ -49,6 +49,7 @@ object EventsConsumer {
   def start() = for {
     _ <- MonitoredTags.updateInterestingContent()
   } {
+    MonitoredTags.start()
     worker.run()
   }
 

--- a/app/com/gu/friendly/tailor/MonitoredTags.scala
+++ b/app/com/gu/friendly/tailor/MonitoredTags.scala
@@ -1,14 +1,21 @@
 package com.gu.friendly.tailor
 
+import java.time.Instant
+
 import com.gu.contentapi.client.GuardianContentClient
 import com.gu.contentapi.client.model.SearchQuery
 import com.typesafe.scalalogging.LazyLogging
+import play.api.libs.concurrent.Akka
 
 import scala.collection.concurrent.TrieMap
 import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.Future
+import scala.concurrent.duration._
+import play.api.Play.current
 
 object MonitoredTags extends LazyLogging {
+
+  case class TagFetchData(fetchTime: Instant, paths: Set[String])
 
   val client = new GuardianContentClient(Config.contentApiKey){
     override val targetUrl=Config.contentTargetUrl
@@ -16,11 +23,19 @@ object MonitoredTags extends LazyLogging {
 
   val tags = Set("politics/eu-referendum", "profile/roberto-tyley")
 
-  val interestingContent = TrieMap.empty[String, Set[String]]
+  val interestingContent = TrieMap.empty[String, TagFetchData]
 
+  def start() = {
+    logger.info("Starting")
+    Akka.system.scheduler.schedule(1.second, 1.minute){
+      updateInterestingContent()
+    }
+  }
 
+  def oldestTagFetchData(): Option[Instant] =
+    interestingContent.values.map(_.fetchTime).toSeq.sorted.headOption
 
-  def tagsForPath(path: String): Set[String] = tags.filter(tag => interestingContent.get(tag).exists(_.contains(path)))
+  def tagsForPath(path: String): Set[String] = tags.filter(tag => interestingContent.get(tag).exists(_.paths.contains(path)))
 
   def updateInterestingContent() = Future.sequence(for { tag <- tags } yield {
     val f = for {
@@ -28,7 +43,7 @@ object MonitoredTags extends LazyLogging {
     } yield {
       val pathSet = result.results.map(c => s"/${c.id}").toSet
       logger.info(s"$tag : ${pathSet.size}")
-      interestingContent(tag) = pathSet
+      interestingContent(tag) = TagFetchData(Instant.now(), pathSet)
     }
     f.onFailure{
       case e => logger.error(s"problem getting $tag", e)

--- a/app/controllers/Management.scala
+++ b/app/controllers/Management.scala
@@ -1,13 +1,18 @@
 package controllers
 
-import com.gu.friendly.tailor.EventsConsumer
+import java.time.Instant
+import java.time.temporal.ChronoUnit.MINUTES
+
+import com.gu.friendly.tailor.{EventsConsumer, MonitoredTags}
 import com.typesafe.scalalogging.LazyLogging
 import play.api.mvc._
 
 object Management extends Controller with LazyLogging {
 
   def healthcheck = Action {
-    Ok(s"OK\n${app.BuildInfo.gitCommitId}\n${EventsConsumer.worker}")
+    val oldestTagFetchData = MonitoredTags.oldestTagFetchData()
+    val message = s"${app.BuildInfo.gitCommitId}\n${EventsConsumer.worker}\noldestTagFetchData: ${oldestTagFetchData.mkString}"
+    if (oldestTagFetchData.exists(_.isAfter(Instant.now.minus(10, MINUTES)))) Ok(message) else ServiceUnavailable(message)
   }
 
 }


### PR DESCRIPTION
We were recording no data for articles that were newer than 6 days old, from when we had last deploy
ed. Fixed so that this automatically refreshes.

cc @rtyley 