### PR TITLE
Add userIdIndexKey in order to allow us to put a Global Secondary Index

### DIFF
--- a/test/com/gu/friendly/tailor/PageViewStorageTest.scala
+++ b/test/com/gu/friendly/tailor/PageViewStorageTest.scala
@@ -7,7 +7,9 @@ import com.gu.scanamo._
 import com.gu.scanamo.syntax._
 import ophan.thrift.event.AssignedId
 
-case class StoredPageViews(browserId: String, userId: String, pageViewsByTag: Map[String, Map[String, Long]])
+import scala.Some
+
+case class StoredPageViews(browserId: String, userId: String, userIdIndexKey: Option[String], pageViewsByTag: Map[String, Map[String, Long]])
 
 class PageViewStorageTest extends org.scalatest.FunSpec with org.scalatest.Matchers {
 
@@ -38,8 +40,28 @@ class PageViewStorageTest extends org.scalatest.FunSpec with org.scalatest.Match
   val entryKey = pageViewStorage.entryKeyFor(fooLooksAtJez)
   val table = pageViewStorage.table
 
-  def getStoredPageViewsForFoo(): StoredPageViews = {
-    Scanamo.get[StoredPageViews](client)(table)('browserId -> "foo" and 'userId -> "None").get.toOption.get
+  def getStoredPageViewsForFoo(userId: Option[String] = None): StoredPageViews = {
+    Scanamo.get[StoredPageViews](client)(table)('browserId -> "foo" and 'userId -> userId.getOrElse("None")).get.toOption.get
+  }
+
+  it("should store a page view entry with userIdIndexKey so we can put a Global Secondary Index on that attribute") {
+    LocalDynamoDB.usingTable(client)(table)('browserId -> S, 'userId -> S) {
+
+      val fooUserId = Some("fooUserId")
+
+      pageViewStorage.putPageView(fooLooksAtJez.copy(userId = fooUserId))
+
+      getStoredPageViewsForFoo(fooUserId).userIdIndexKey shouldBe fooUserId
+    }
+  }
+
+  it("should not set any value in the userIdIndexKey if there is no userId present, so that the GSI does not have bad hash distribution") {
+    LocalDynamoDB.usingTable(client)(table)('browserId -> S, 'userId -> S) {
+
+      pageViewStorage.putPageView(fooLooksAtJez.copy(userId = None))
+
+      getStoredPageViewsForFoo().userIdIndexKey shouldBe None
+    }
   }
 
   it("should update a nested map") {


### PR DESCRIPTION
See doc for further detail: http://docs.aws.amazon.com/amazondynamodb/latest/developerguide/GSI.html

This will allow us to query user history based on userId, and give us cross-browser history for logged in users.

More tests to ensure that userIdIndexKey works well with global secondary index

cc @rtyley 